### PR TITLE
Added libncruses5-dev to debuian arch64

### DIFF
--- a/tools/host_det.sh
+++ b/tools/host_det.sh
@@ -242,6 +242,8 @@ debian_regs () {
 			unset dpkg_multiarch
 			case "${deb_distro}" in
 			squeeze|lucid|precise)
+				pkg="libncurses5-dev"
+				check_dpkg
 				pkg="ia32-libs"
 				check_dpkg
 				;;


### PR DESCRIPTION
menu compilation failed with Ubuntu 12.4.2 LTS 64 bits
